### PR TITLE
Add Warning to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 Script to automatically inject _hreflang_ tags and snippets into all pages into
 your Webflow or Squarespace website
 
+### NOTE: 
+
+Before running this script, please be aware that any existing text/scripts inside your Webflow or Squarespace page headers will be overwritten.
+
+
 ### Requirements
 
 `node >=10`


### PR DESCRIPTION
After using this script, my existing scripts were completely wiped -  had to completely restore my Webflow site and rewire my CMSIDs to get them back, which is a multi-hour effort and rendered this software useless anyway. I guess I should've read the code in detail before I used it.

Adding a warning for other users; highly suggest the authors change the code so this situation doesn't occur for others. I don't currently have time to, so adding this for now.